### PR TITLE
Integrate event flows with Hasura backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_HASURA_GRAPHQL_URL=https://whatsapp-hasura.t2wird.easypanel.host/v1/graphql
+VITE_HASURA_ADMIN_SECRET=mysecretkey
+# VITE_HASURA_JWT_TOKEN=coloque_o_token_de_teste_aqui

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment configuration
+
+The screens that consult or gerenciam eventos depend on a Hasura instance. Configure the following environment variables before running the app locally:
+
+```sh
+cp .env.example .env
+```
+
+Edit `.env` and provide your credentials:
+
+```dotenv
+VITE_HASURA_GRAPHQL_URL=https://whatsapp-hasura.t2wird.easypanel.host/v1/graphql
+VITE_HASURA_ADMIN_SECRET=mysecretkey # substitua pelo segredo correto em produção
+```
+
+The admin secret is required to listar eventos públicos (busca) enquanto o token JWT (obtido via backend de autenticação) será encaminhado automaticamente para operações autenticadas como criar, listar e remover eventos do fotógrafo.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/3412fe1e-9430-4a93-9ee1-ba28dca3541f) and click on Share -> Publish.

--- a/src/lib/graphqlClient.ts
+++ b/src/lib/graphqlClient.ts
@@ -1,0 +1,74 @@
+const HASURA_GRAPHQL_URL = import.meta.env.VITE_HASURA_GRAPHQL_URL ??
+  "https://whatsapp-hasura.t2wird.easypanel.host/v1/graphql";
+
+const HASURA_ADMIN_SECRET = import.meta.env.VITE_HASURA_ADMIN_SECRET;
+
+export interface GraphQLRequestOptions {
+  token?: string | null;
+  useAdminSecret?: boolean;
+  headers?: HeadersInit;
+  signal?: AbortSignal;
+}
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}
+
+export class GraphQLError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GraphQLError";
+  }
+}
+
+export async function graphqlRequest<T>(
+  query: string,
+  variables: Record<string, unknown> = {},
+  options: GraphQLRequestOptions = {}
+): Promise<T> {
+  const { token, useAdminSecret, headers, signal } = options;
+
+  const requestHeaders: HeadersInit = {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    ...headers,
+  };
+
+  if (token) {
+    requestHeaders["Authorization"] = `Bearer ${token}`;
+  }
+
+  if (useAdminSecret) {
+    if (!HASURA_ADMIN_SECRET) {
+      console.warn("VITE_HASURA_ADMIN_SECRET não definido. A requisição pode falhar.");
+    } else {
+      requestHeaders["x-hasura-admin-secret"] = HASURA_ADMIN_SECRET;
+    }
+  }
+
+  const response = await fetch(HASURA_GRAPHQL_URL, {
+    method: "POST",
+    headers: requestHeaders,
+    body: JSON.stringify({ query, variables }),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new GraphQLError(`Falha na requisição GraphQL (${response.status})`);
+  }
+
+  const payload = (await response.json()) as GraphQLResponse<T>;
+
+  if (payload.errors && payload.errors.length > 0) {
+    throw new GraphQLError(payload.errors.map((error) => error.message).join("\n"));
+  }
+
+  if (!payload.data) {
+    throw new GraphQLError("Resposta GraphQL sem dados");
+  }
+
+  return payload.data;
+}
+
+export type { GraphQLResponse };

--- a/src/pages/PhotographerEventCreate.tsx
+++ b/src/pages/PhotographerEventCreate.tsx
@@ -20,7 +20,8 @@ const PhotographerEventCreate = () => {
     data: '',
     local: '',
     categoria: '',
-    precoBase: ''
+    precoBase: '',
+    capa: '',
   });
   const [categories, setCategories] = useState<EventCategory[]>([]);
   const [isLoadingCategories, setIsLoadingCategories] = useState(false);
@@ -71,7 +72,9 @@ const PhotographerEventCreate = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!eventForm.nome || !eventForm.data || !eventForm.local || !eventForm.categoria) {
+    const coverUrl = eventForm.capa.trim();
+
+    if (!eventForm.nome || !eventForm.data || !eventForm.local || !eventForm.categoria || !coverUrl) {
       toast({
         title: "Campos obrigatórios",
         description: "Por favor, preencha todos os campos obrigatórios.",
@@ -118,6 +121,7 @@ const PhotographerEventCreate = () => {
           status: 'draft',
           visibility: 'public',
           category_id: eventForm.categoria,
+          cover_url: coverUrl,
         },
         accessToken
       );
@@ -205,6 +209,20 @@ const PhotographerEventCreate = () => {
                     </p>
                   )}
                 </div>
+              </div>
+
+              <div>
+                <Label htmlFor="capa">Imagem de capa *</Label>
+                <Input
+                  id="capa"
+                  value={eventForm.capa}
+                  onChange={(e) => setEventForm(prev => ({ ...prev, capa: e.target.value }))}
+                  placeholder="Cole o link da imagem de destaque do evento"
+                  required
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  Use uma URL de imagem pública que represente o evento.
+                </p>
               </div>
 
               <div>

--- a/src/pages/PhotographerEventCreate.tsx
+++ b/src/pages/PhotographerEventCreate.tsx
@@ -8,9 +8,12 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { toast } from '@/hooks/use-toast';
 import Header from '@/components/Header';
+import { useAuth } from '@/contexts/AuthContext';
+import { createEvent } from '@/services/eventService';
 
 const PhotographerEventCreate = () => {
   const navigate = useNavigate();
+  const { user, accessToken } = useAuth();
   const [eventForm, setEventForm] = useState({
     nome: '',
     descricao: '',
@@ -19,6 +22,7 @@ const PhotographerEventCreate = () => {
     categoria: '',
     precoBase: ''
   });
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const categories = [
     'Corrida de rua',
@@ -32,9 +36,9 @@ const PhotographerEventCreate = () => {
     'Outro'
   ];
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!eventForm.nome || !eventForm.data || !eventForm.local || !eventForm.categoria) {
       toast({
         title: "Campos obrigatórios",
@@ -44,16 +48,63 @@ const PhotographerEventCreate = () => {
       return;
     }
 
-    // Mock creation - generate random ID
-    const eventId = Math.random().toString(36).substr(2, 9);
-    
-    toast({
-      title: "Evento criado (mock)!",
-      description: `O evento "${eventForm.nome}" foi criado com sucesso.`,
-    });
-    
-    // Redirect to event details
-    navigate(`/fotografo/eventos/${eventId}`);
+    if (!user?.id || !accessToken) {
+      toast({
+        title: 'Sessão expirada',
+        description: 'Faça login novamente para criar um evento.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const parseLocation = (value: string) => {
+      if (!value) return { city: null, state: null };
+      const sanitized = value.replace(/,/g, '-');
+      const [cityPart, statePart] = sanitized.split('-').map((part) => part.trim());
+      return {
+        city: cityPart || null,
+        state: statePart || null,
+      };
+    };
+
+    try {
+      setIsSubmitting(true);
+      const { city, state } = parseLocation(eventForm.local);
+      const startAt = new Date(`${eventForm.data}T00:00:00`);
+      const basePriceCents = eventForm.precoBase ? Math.round(parseFloat(eventForm.precoBase) * 100) : null;
+
+      const created = await createEvent(
+        {
+          title: eventForm.nome,
+          description: eventForm.descricao || null,
+          start_at: Number.isNaN(startAt.getTime()) ? new Date().toISOString() : startAt.toISOString(),
+          city,
+          state,
+          venue_name: city,
+          base_price_cents: basePriceCents,
+          owner_id: user.id,
+          status: 'draft',
+          visibility: 'public',
+        },
+        accessToken
+      );
+
+      toast({
+        title: 'Evento criado!',
+        description: `O evento "${created.title}" foi criado com sucesso.`,
+      });
+
+      navigate(`/fotografo/eventos/${created.id}`);
+    } catch (error) {
+      console.error('Erro ao criar evento', error);
+      toast({
+        title: 'Erro ao criar evento',
+        description: error instanceof Error ? error.message : 'Não foi possível criar o evento.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -141,12 +192,12 @@ const PhotographerEventCreate = () => {
               </div>
 
               <div className="flex gap-4 pt-4">
-                <Button type="submit" className="flex-1">
-                  Criar Evento
+                <Button type="submit" className="flex-1" disabled={isSubmitting}>
+                  {isSubmitting ? 'Criando...' : 'Criar Evento'}
                 </Button>
-                <Button 
-                  type="button" 
-                  variant="outline" 
+                <Button
+                  type="button"
+                  variant="outline"
                   onClick={() => navigate('/fotografo/eventos')}
                   className="flex-1"
                 >

--- a/src/pages/PhotographerEvents.tsx
+++ b/src/pages/PhotographerEvents.tsx
@@ -1,70 +1,77 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, Calendar, MapPin, Users } from 'lucide-react';
+import { Plus, Calendar, MapPin, DollarSign } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import Header from '@/components/Header';
+import { useAuth } from '@/contexts/AuthContext';
+import { EventSummary, listPhotographerEvents } from '@/services/eventService';
 
 const PhotographerEvents = () => {
   const navigate = useNavigate();
-  
-  // Mock events data
-  const [events] = useState([
-    {
-      id: '1',
-      nome: 'Corrida de 5k Centro Histórico',
-      data: '2024-03-15',
-      local: 'Centro Histórico, Fortaleza - CE',
-      categoria: 'Corrida de rua',
-      participantes: 250,
-      fotos: 340,
-      status: 'ativo'
-    },
-    {
-      id: '2',
-      nome: 'Triathlon Praia do Futuro',
-      data: '2024-02-28',
-      local: 'Praia do Futuro, Fortaleza - CE',
-      categoria: 'Triathlon',
-      participantes: 180,
-      fotos: 520,
-      status: 'concluido'
-    },
-    {
-      id: '3',
-      nome: 'Maratona da Cidade',
-      data: '2024-04-20',
-      local: 'Aterro da Praia de Iracema, Fortaleza - CE',
-      categoria: 'Maratona',
-      participantes: 500,
-      fotos: 0,
-      status: 'agendado'
-    }
-  ]);
+  const { user, accessToken } = useAuth();
+  const [events, setEvents] = useState<EventSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'ativo': return 'bg-green-100 text-green-800';
-      case 'concluido': return 'bg-blue-100 text-blue-800';
-      case 'agendado': return 'bg-yellow-100 text-yellow-800';
-      default: return 'bg-gray-100 text-gray-800';
+  useEffect(() => {
+    if (!user?.id || !accessToken) {
+      setEvents([]);
+      setIsLoading(false);
+      return;
     }
+
+    const controller = new AbortController();
+    setIsLoading(true);
+    setError(null);
+
+    listPhotographerEvents(user.id, accessToken, controller.signal)
+      .then((data) => {
+        setEvents(data);
+      })
+      .catch((err) => {
+        if (err.name === 'AbortError') return;
+        console.error('Erro ao carregar eventos do fotógrafo', err);
+        setError(err instanceof Error ? err.message : 'Não foi possível carregar seus eventos.');
+      })
+      .finally(() => setIsLoading(false));
+
+    return () => controller.abort();
+  }, [user?.id, accessToken]);
+
+  const statusBadges = useMemo(
+    () => ({
+      active: { color: 'bg-green-100 text-green-800', label: 'Em andamento' },
+      scheduled: { color: 'bg-yellow-100 text-yellow-800', label: 'Agendado' },
+      completed: { color: 'bg-blue-100 text-blue-800', label: 'Concluído' },
+      draft: { color: 'bg-gray-100 text-gray-800', label: 'Rascunho' },
+      archived: { color: 'bg-gray-100 text-gray-800', label: 'Arquivado' },
+    } as const),
+    []
+  );
+
+  const formatDate = (value?: string | null) => {
+    if (!value) return 'Data a definir';
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return 'Data a definir';
+    return parsed.toLocaleDateString('pt-BR');
   };
 
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case 'ativo': return 'Em andamento';
-      case 'concluido': return 'Concluído';
-      case 'agendado': return 'Agendado';
-      default: return status;
-    }
+  const formatLocation = (event: EventSummary) => {
+    if (event.city && event.state) return `${event.city} ${event.state}`.trim();
+    return event.city || event.state || 'Local a definir';
+  };
+
+  const formatPrice = (value?: number | null) => {
+    if (!value) return 'Valor a definir';
+    return (value / 100).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
   };
 
   return (
     <div className="min-h-screen bg-background">
       <Header title="Meus Eventos" showCart={false} showBack={true} />
-      
+
       <div className="container mx-auto px-4 py-8">
         <div className="flex justify-between items-center mb-8">
           <h1 className="text-3xl font-bold">Meus Eventos</h1>
@@ -74,50 +81,59 @@ const PhotographerEvents = () => {
           </Button>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {events.map((event) => (
-            <Card key={event.id} className="hover:shadow-lg transition-shadow cursor-pointer" onClick={() => navigate(`/fotografo/eventos/${event.id}`)}>
-              <CardHeader>
-                <div className="flex justify-between items-start">
-                  <CardTitle className="text-lg">{event.nome}</CardTitle>
-                  <Badge className={getStatusColor(event.status)}>
-                    {getStatusText(event.status)}
-                  </Badge>
-                </div>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Calendar size={16} />
-                  <span>{new Date(event.data).toLocaleDateString('pt-BR')}</span>
-                </div>
-                
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <MapPin size={16} />
-                  <span>{event.local}</span>
-                </div>
+        {isLoading && <p className="text-center text-muted-foreground py-12">Carregando seus eventos...</p>}
 
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <Users size={16} />
-                  <span>{event.participantes} participantes</span>
-                </div>
+        {error && !isLoading && (
+          <div className="text-center py-12 text-red-500">{error}</div>
+        )}
 
-                <div className="pt-2 border-t">
-                  <p className="text-sm">
-                    <span className="font-semibold">{event.fotos}</span> fotos enviadas
-                  </p>
-                </div>
+        {!isLoading && !error && events.length > 0 && (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {events.map((event) => {
+              const statusKey = event.status ?? 'draft';
+              const statusInfo = statusBadges[statusKey as keyof typeof statusBadges] ?? statusBadges.draft;
 
-                <Badge variant="outline">{event.categoria}</Badge>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+              return (
+                <Card
+                  key={event.id}
+                  className="hover:shadow-lg transition-shadow cursor-pointer"
+                  onClick={() => navigate(`/fotografo/eventos/${event.id}`)}
+                >
+                  <CardHeader>
+                    <div className="flex justify-between items-start">
+                      <CardTitle className="text-lg">{event.title}</CardTitle>
+                      <Badge className={statusInfo.color}>{statusInfo.label}</Badge>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Calendar size={16} />
+                      <span>{formatDate(event.start_at)}</span>
+                    </div>
 
-        {events.length === 0 && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <MapPin size={16} />
+                      <span>{formatLocation(event)}</span>
+                    </div>
+
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <DollarSign size={16} />
+                      <span>{formatPrice(event.base_price_cents)}</span>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+
+        {!isLoading && !error && events.length === 0 && (
           <div className="text-center py-16">
             <Calendar size={64} className="mx-auto text-muted-foreground mb-4" />
             <h3 className="text-xl font-semibold mb-2">Nenhum evento encontrado</h3>
-            <p className="text-muted-foreground mb-6">Comece criando seu primeiro evento.</p>
+            <p className="text-muted-foreground mb-6">
+              Comece criando seu primeiro evento e publique suas fotos.
+            </p>
             <Button onClick={() => navigate('/fotografo/eventos/novo')} className="flex items-center gap-2">
               <Plus size={20} />
               Criar Primeiro Evento

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -243,14 +243,34 @@ export interface CreateEventInput {
   owner_id: string;
   status?: string;
   visibility?: string;
+  slug?: string;
+}
+
+function generateEventSlug(title: string) {
+  const baseSlug = title
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+
+  const uniqueSuffix = Math.random().toString(36).slice(2, 8);
+  const sanitizedBase = baseSlug || 'evento';
+
+  return `${sanitizedBase}-${uniqueSuffix}`;
 }
 
 export async function createEvent(input: CreateEventInput, token: string) {
   try {
+    const slug = input.slug ?? generateEventSlug(input.title);
     const data = await graphqlRequest<{ insert_events_one: EventSummary }>(
       CREATE_EVENT_MUTATION,
       {
-        object: input,
+        object: {
+          ...input,
+          slug,
+        },
       },
       {
         token,

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -203,7 +203,7 @@ export async function listPhotographerEvents(ownerId: string, token: string, sig
   const where = {
     _and: [
       { owner_id: { _eq: ownerId } },
-      { status: { _nlike: "archived" } },
+      { status: { _neq: "archived" } },
     ],
   } as const;
 
@@ -273,6 +273,7 @@ export interface CreateEventInput {
   status?: string;
   visibility?: string;
   category_id: string;
+  cover_url: string;
   slug?: string;
 }
 

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -26,6 +26,12 @@ export interface EventDetail extends EventSummary {
   published_at?: string | null;
 }
 
+export interface EventCategory {
+  id: string;
+  name: string;
+  slug?: string | null;
+}
+
 export interface SearchEventsParams {
   searchTerm?: string;
   city?: string;
@@ -115,6 +121,16 @@ const EVENT_BY_SLUG_QUERY = /* GraphQL */ `
       created_at
       updated_at
       published_at
+    }
+  }
+`;
+
+const LIST_EVENT_CATEGORIES_QUERY = /* GraphQL */ `
+  query EventCategories {
+    event_categories(order_by: { name: asc }) {
+      id
+      name
+      slug
     }
   }
 `;
@@ -231,6 +247,19 @@ export async function getEventBySlug(slug: string, token?: string | null, signal
   return data.events[0] ?? null;
 }
 
+export async function listEventCategories(token?: string | null, signal?: AbortSignal) {
+  const data = await graphqlRequest<{ event_categories: EventCategory[] }>(
+    LIST_EVENT_CATEGORIES_QUERY,
+    {},
+    {
+      token: token ?? undefined,
+      useAdminSecret: token ? false : true,
+      signal,
+    }
+  );
+  return data.event_categories;
+}
+
 export interface CreateEventInput {
   title: string;
   description?: string | null;
@@ -243,6 +272,7 @@ export interface CreateEventInput {
   owner_id: string;
   status?: string;
   visibility?: string;
+  category_id: string;
   slug?: string;
 }
 

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -1,0 +1,283 @@
+import { graphqlRequest, GraphQLError } from '@/lib/graphqlClient';
+
+export interface EventSummary {
+  id: string;
+  slug?: string | null;
+  title: string;
+  description?: string | null;
+  cover_url?: string | null;
+  city?: string | null;
+  state?: string | null;
+  start_at?: string | null;
+  end_at?: string | null;
+  base_price_cents?: number | null;
+  status?: string | null;
+  visibility?: string | null;
+}
+
+export interface EventDetail extends EventSummary {
+  venue_name?: string | null;
+  street?: string | null;
+  country?: string | null;
+  timezone?: string | null;
+  owner_id?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  published_at?: string | null;
+}
+
+export interface SearchEventsParams {
+  searchTerm?: string;
+  city?: string;
+  limit?: number;
+  offset?: number;
+}
+
+const SEARCH_EVENTS_QUERY = /* GraphQL */ `
+  query SearchEvents($where: events_bool_exp!, $limit: Int = 20, $offset: Int = 0) {
+    events(where: $where, order_by: { start_at: desc_nulls_last, created_at: desc }, limit: $limit, offset: $offset) {
+      id
+      slug
+      title
+      description
+      cover_url
+      city
+      state
+      start_at
+      end_at
+      base_price_cents
+      status
+      visibility
+    }
+  }
+`;
+
+const PHOTOGRAPHER_EVENTS_QUERY = /* GraphQL */ `
+  query PhotographerEvents($where: events_bool_exp!, $limit: Int = 50) {
+    events(where: $where, order_by: { start_at: desc_nulls_last, created_at: desc }, limit: $limit) {
+      id
+      slug
+      title
+      description
+      city
+      state
+      start_at
+      status
+      base_price_cents
+      cover_url
+    }
+  }
+`;
+
+const EVENT_BY_ID_QUERY = /* GraphQL */ `
+  query EventById($id: uuid!) {
+    events_by_pk(id: $id) {
+      id
+      slug
+      title
+      description
+      cover_url
+      city
+      state
+      street
+      venue_name
+      start_at
+      end_at
+      base_price_cents
+      status
+      visibility
+      owner_id
+      created_at
+      updated_at
+      published_at
+    }
+  }
+`;
+
+const EVENT_BY_SLUG_QUERY = /* GraphQL */ `
+  query EventBySlug($slug: String!) {
+    events(where: { slug: { _eq: $slug } }, limit: 1) {
+      id
+      slug
+      title
+      description
+      cover_url
+      city
+      state
+      street
+      venue_name
+      start_at
+      end_at
+      base_price_cents
+      status
+      visibility
+      owner_id
+      created_at
+      updated_at
+      published_at
+    }
+  }
+`;
+
+const CREATE_EVENT_MUTATION = /* GraphQL */ `
+  mutation CreateEvent($object: events_insert_input!) {
+    insert_events_one(object: $object) {
+      id
+      slug
+      title
+      start_at
+      city
+      state
+    }
+  }
+`;
+
+const DELETE_EVENT_MUTATION = /* GraphQL */ `
+  mutation DeleteEvent($id: uuid!) {
+    delete_events_by_pk(id: $id) {
+      id
+    }
+  }
+`;
+
+const DEFAULT_EVENT_STATUSES = ["active", "scheduled", "completed"];
+
+function buildSearchWhere(params: SearchEventsParams) {
+  const filters: Record<string, unknown>[] = [
+    { status: { _in: DEFAULT_EVENT_STATUSES } },
+  ];
+
+  if (params.city) {
+    filters.push({ city: { _ilike: params.city } });
+  }
+
+  const term = params.searchTerm?.trim();
+  if (term) {
+    const pattern = `%${term.replace(/\s+/g, "%")}%`;
+    filters.push({
+      _or: [
+        { title: { _ilike: pattern } },
+        { description: { _ilike: pattern } },
+        { city: { _ilike: pattern } },
+      ],
+    });
+  }
+
+  return { _and: filters };
+}
+
+export async function searchEvents(params: SearchEventsParams = {}, signal?: AbortSignal) {
+  const where = buildSearchWhere(params);
+  const data = await graphqlRequest<{ events: EventSummary[] }>(
+    SEARCH_EVENTS_QUERY,
+    {
+      where,
+      limit: params.limit ?? 20,
+      offset: params.offset ?? 0,
+    },
+    {
+      useAdminSecret: true,
+      signal,
+    }
+  );
+  return data.events;
+}
+
+export async function listPhotographerEvents(ownerId: string, token: string, signal?: AbortSignal) {
+  const where = {
+    _and: [
+      { owner_id: { _eq: ownerId } },
+      { status: { _nlike: "archived" } },
+    ],
+  } as const;
+
+  const data = await graphqlRequest<{ events: EventSummary[] }>(
+    PHOTOGRAPHER_EVENTS_QUERY,
+    {
+      where,
+      limit: 100,
+    },
+    {
+      token,
+      signal,
+    }
+  );
+  return data.events;
+}
+
+export async function getEventById(id: string, token?: string | null, signal?: AbortSignal) {
+  const data = await graphqlRequest<{ events_by_pk: EventDetail | null }>(
+    EVENT_BY_ID_QUERY,
+    { id },
+    {
+      token: token ?? undefined,
+      useAdminSecret: token ? false : true,
+      signal,
+    }
+  );
+  return data.events_by_pk;
+}
+
+export async function getEventBySlug(slug: string, token?: string | null, signal?: AbortSignal) {
+  const data = await graphqlRequest<{ events: EventDetail[] }>(
+    EVENT_BY_SLUG_QUERY,
+    { slug },
+    {
+      token: token ?? undefined,
+      useAdminSecret: token ? false : true,
+      signal,
+    }
+  );
+  return data.events[0] ?? null;
+}
+
+export interface CreateEventInput {
+  title: string;
+  description?: string | null;
+  start_at: string;
+  end_at?: string | null;
+  city?: string | null;
+  state?: string | null;
+  venue_name?: string | null;
+  base_price_cents?: number | null;
+  owner_id: string;
+  status?: string;
+  visibility?: string;
+}
+
+export async function createEvent(input: CreateEventInput, token: string) {
+  try {
+    const data = await graphqlRequest<{ insert_events_one: EventSummary }>(
+      CREATE_EVENT_MUTATION,
+      {
+        object: input,
+      },
+      {
+        token,
+      }
+    );
+    return data.insert_events_one;
+  } catch (error) {
+    if (error instanceof GraphQLError) {
+      throw new Error(error.message);
+    }
+    throw error;
+  }
+}
+
+export async function deleteEvent(id: string, token: string) {
+  try {
+    await graphqlRequest<{ delete_events_by_pk: { id: string } | null }>(
+      DELETE_EVENT_MUTATION,
+      { id },
+      {
+        token,
+      }
+    );
+  } catch (error) {
+    if (error instanceof GraphQLError) {
+      throw new Error(error.message);
+    }
+    throw error;
+  }
+}

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -275,6 +275,9 @@ export interface CreateEventInput {
   category_id: string;
   cover_url: string;
   slug?: string;
+  timezone?: string | null;
+  country?: string | null;
+  currency?: string | null;
 }
 
 function generateEventSlug(title: string) {
@@ -295,11 +298,21 @@ function generateEventSlug(title: string) {
 export async function createEvent(input: CreateEventInput, token: string) {
   try {
     const slug = input.slug ?? generateEventSlug(input.title);
+    const timezone = input.timezone ?? 'America/Sao_Paulo';
+    const country = input.country ?? 'BR';
+    const currency = input.currency ?? 'BRL';
+    const status = input.status ?? 'draft';
+    const visibility = input.visibility ?? 'public';
     const data = await graphqlRequest<{ insert_events_one: EventSummary }>(
       CREATE_EVENT_MUTATION,
       {
         object: {
           ...input,
+          status,
+          visibility,
+          timezone,
+          country,
+          currency,
           slug,
         },
       },


### PR DESCRIPTION
## Summary
- add a reusable GraphQL client and event service for Hasura interactions using admin secret or JWT
- replace mocked data on public search and photographer flows with live event queries and mutations
- refresh event detail experience and document required environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d578119808832a845cc897aaddd98f