### PR TITLE
Use Hasura endpoint from VITE_HASURA_GRAPHQL_URL

### DIFF
--- a/src/data/adminMock.ts
+++ b/src/data/adminMock.ts
@@ -630,7 +630,7 @@ export interface AdminIntegrationConfig {
 }
 
 export const adminIntegrationConfig: AdminIntegrationConfig = {
-  hasuraEndpoint: 'https://infra-olha-a-foto-backend.k3p3ex.easypanel.host/v1/graphql',
+  hasuraEndpoint: import.meta.env.VITE_HASURA_GRAPHQL_URL ?? '',
   adminSecretMasked: 'hasura-admin-***',
   analyticsProvider: 'Posthog Cloud (região: US)',
   storageProvider: 'Google Cloud Storage',

--- a/src/lib/graphqlClient.ts
+++ b/src/lib/graphqlClient.ts
@@ -1,5 +1,4 @@
-const HASURA_GRAPHQL_URL = import.meta.env.VITE_HASURA_GRAPHQL_URL ??
-  "https://whatsapp-hasura.t2wird.easypanel.host/v1/graphql";
+const HASURA_GRAPHQL_URL = import.meta.env.VITE_HASURA_GRAPHQL_URL;
 
 const HASURA_ADMIN_SECRET = import.meta.env.VITE_HASURA_ADMIN_SECRET;
 
@@ -27,6 +26,9 @@ export async function graphqlRequest<T>(
   variables: Record<string, unknown> = {},
   options: GraphQLRequestOptions = {}
 ): Promise<T> {
+  if (!HASURA_GRAPHQL_URL) {
+    throw new GraphQLError("VITE_HASURA_GRAPHQL_URL não definido.");
+  }
   const { token, useAdminSecret, headers, signal } = options;
 
   const requestHeaders: HeadersInit = {


### PR DESCRIPTION
### Motivation
- Ensure all GraphQL requests use the Hasura URL configured in `VITE_HASURA_GRAPHQL_URL` instead of silently falling back to a hardcoded endpoint.
- Reflect the configured Hasura endpoint in admin integration mock data so UI/admin pages match runtime configuration.

### Description
- Removed the hardcoded fallback URL and read `HASURA_GRAPHQL_URL` strictly from `import.meta.env.VITE_HASURA_GRAPHQL_URL` in `src/lib/graphqlClient.ts`.
- Added a runtime check in `graphqlRequest` that throws a `GraphQLError` when `VITE_HASURA_GRAPHQL_URL` is not defined.
- Updated `src/data/adminMock.ts` to use `import.meta.env.VITE_HASURA_GRAPHQL_URL ?? ''` for the `hasuraEndpoint` mock value.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678fe8e7ac832ab8cc5013d7091bb1)